### PR TITLE
Fix breaking out of the loop early

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = postcss.plugin('postcss-clearfix', function () {
 
       // if we're not dealing with a clear: declaration exit
       if (prop !== 'clear') {
-        return false;
+        return;
       }
 
       // pass all clear: fix; properties to the clearFix handler


### PR DESCRIPTION
Seems like there was an API change, but with the latest postcss if you return `false` it will break out of the each early. https://github.com/postcss/postcss/blob/master/docs/api.md#containereachcallback

This PR fixes that.